### PR TITLE
Add usage notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ This extension has the following settings:
 
 - `codewall.openProblemsPane`: Determines whether to open the problems pane to show warnings when lines cross rulers. Is true by default.
 
+## Usage
+Add a rulers using the `editor.rulers` setting (`Command Palette -> Preferences: Open Settings (JSON)`).
+
+Valid Values:
+
+```json
+"editor.rulers": [
+  {"column": 90, "color": "#000"}
+  {"column": 105, "color": "#ff0000"}
+]
+```
+
+```json
+"editor.rulers": [90, 105]
+```
+
 ## CodeWall for Atom
 
 Don't use VS Code? Try [CodeWall](https://github.com/Oceanwall/CodeWall) for Atom, made by Oceanwall!


### PR DESCRIPTION
It makes it easier to know how to use the plugin especially for VS Code new comers.